### PR TITLE
Empty page messages

### DIFF
--- a/src/containers/PracticeCards/PracticeCards.js
+++ b/src/containers/PracticeCards/PracticeCards.js
@@ -40,6 +40,13 @@ checkGuess = (word) => {
     // prompt 'incorrect guess' message
   }
 }
+  checkContents = () => {
+    if (this.props.vocabList.length > 0 ) {
+      return 'hidden';
+    } else {
+      return 'visible';
+    }
+  }
 
  render() {
     let shuffledList = this.shuffleList(this.props.vocabList);
@@ -73,6 +80,7 @@ checkGuess = (word) => {
 
    return (
      <section className='list-container'>
+       <h1 className={`${this.checkContents()} empty-message`}>Add some words to your vocab list to practice them!</h1>
        {cards}
      </section>
    )

--- a/src/containers/PracticeCards/PracticeCards.test.js
+++ b/src/containers/PracticeCards/PracticeCards.test.js
@@ -15,12 +15,14 @@ describe('PracticeCards', () => {
       let unshuffled = [1,2,3,4]
       expect(wrapper.instance().shuffleList(unshuffled).length).toEqual(unshuffled.length)
     })
+
     it('should call checkGuess when the checkGuess button is clicked', () => {
       wrapper = shallow(<PracticeCards vocabList={[{word: 'word', results: [{definition: 'definition', partOfSpeech: 'noun'}, {}]}]}/>)
       wrapper.instance().checkGuess = jest.fn();
       wrapper.find('.check-guess').simulate('click');
       expect(wrapper.instance().checkGuess).toHaveBeenCalled()
     })
+
     it('should update state when a word is guessed correctly', () => {
       wrapper = shallow(<PracticeCards vocabList={[{word: 'word', results: [{definition: 'definition', partOfSpeech: 'noun'}, {}]}]}/>)
       const startState = {guess: 'hat', correctlyGuessedWords: []};
@@ -29,6 +31,7 @@ describe('PracticeCards', () => {
       wrapper.instance().checkGuess('hat');
       expect(wrapper.state()).toEqual(expected);
     })
+
     it('should update state when handleChange is called', () => {
       const startState = {guess: '', correctlyGuessedWords: []};
       wrapper = shallow(<PracticeCards vocabList={[{word: 'word', results: [{definition: 'definition', partOfSpeech: 'noun'}, {}]}]}/>)
@@ -37,6 +40,16 @@ describe('PracticeCards', () => {
       const expected = {guess: 'hat', correctlyGuessedWords: []};
       wrapper.instance().handleChange(mockEvent);
       expect(wrapper.state('guess')).toEqual(expected.guess);
+    })
+
+    it('should return hidden if vocabList is not empty', () => {
+      wrapper = shallow(<PracticeCards vocabList={[{word: 'word', results: [{definition: 'definition', partOfSpeech: 'noun'}, {}]}]}/>)
+      expect(wrapper.instance().checkContents()).toEqual('hidden')
+    })
+
+    it('should return visible if vocabList is empty', () => {
+      wrapper = shallow(<PracticeCards vocabList={[]}/>)
+      expect(wrapper.instance().checkContents()).toEqual('visible')
     })
   })
 

--- a/src/containers/PracticeCards/__snapshots__/PracticeCards.test.js.snap
+++ b/src/containers/PracticeCards/__snapshots__/PracticeCards.test.js.snap
@@ -4,6 +4,11 @@ exports[`PracticeCards should match the snapshot 1`] = `
 <section
   className="list-container"
 >
+  <h1
+    className="hidden empty-message"
+  >
+    Add some words to your vocab list to practice them!
+  </h1>
   <section
     className="list-card"
     key="word"

--- a/src/containers/VocabList/VocabList.js
+++ b/src/containers/VocabList/VocabList.js
@@ -9,6 +9,13 @@ export class VocabList extends Component {
   constructor() {
     super();
  }
+ checkContents = () => {
+   if (this.props.vocabList.length > 0 ) {
+     return 'hidden';
+   } else {
+     return 'visible';
+   }
+ }
 
  render() {
    let listCards = this.props.vocabList.map(word => {
@@ -24,6 +31,7 @@ export class VocabList extends Component {
   })
    return (
     <section className='list-container'>
+      <h1 className={`${this.checkContents()} empty-message`}>Add some words to your vocab list to view them here!</h1>
       {listCards}
     </section>
    )

--- a/src/containers/VocabList/VocabList.scss
+++ b/src/containers/VocabList/VocabList.scss
@@ -8,6 +8,14 @@
   flex-wrap: wrap;
 }
 
+.empty-message {
+  color: white;
+  font-size: 2rem;
+}
+
+.hidden {
+  display: none;
+}
 
 .list-card {
   margin-top: 2rem;

--- a/src/containers/VocabList/VocabList.test.js
+++ b/src/containers/VocabList/VocabList.test.js
@@ -4,6 +4,7 @@ import { VocabList, mapStateToProps, mapDispatchToProps } from './VocabList';
 import { shallow } from 'enzyme';
 
 describe('VocabList', () => {
+  let wrapper;
   it('should match the snapshot', () => {
     let wrapper = shallow(<VocabList vocabList=
       {
@@ -17,6 +18,16 @@ describe('VocabList', () => {
       }
     />);
     expect(wrapper).toMatchSnapshot();
+  })
+  describe('Method Tests', () => {
+    it('should return hidden if vocabList is not empty', () => {
+      wrapper = shallow(<VocabList vocabList={[{word: 'word', results: [{definition: 'definition', partOfSpeech: 'noun'}, {}]}]}/>)
+      expect(wrapper.instance().checkContents()).toEqual('hidden')
+    })
+    it('should return visible if vocabList is empty', () => {
+      wrapper = shallow(<VocabList vocabList={[]}/>)
+      expect(wrapper.instance().checkContents()).toEqual('visible')
+    })
   })
   describe('mapStateToProps', () => {
     it('should return an object with the vocabList array', () => {

--- a/src/containers/VocabList/__snapshots__/VocabList.test.js.snap
+++ b/src/containers/VocabList/__snapshots__/VocabList.test.js.snap
@@ -4,6 +4,11 @@ exports[`VocabList should match the snapshot 1`] = `
 <section
   className="list-container"
 >
+  <h1
+    className="hidden empty-message"
+  >
+    Add some words to your vocab list to view them here!
+  </h1>
   <section
     className="list-card"
     key="word"


### PR DESCRIPTION
### What does this PR do? 
This PR adds some messages that render if the practice or VocabList pages are empty. If there are cards on those pages, the message goes away. 
### Can this be tested?
Yes, and it has been 
### Issues 
none